### PR TITLE
landing page for developers meetup

### DIFF
--- a/developersmeetup/index.md
+++ b/developersmeetup/index.md
@@ -1,0 +1,36 @@
+---
+layout: common
+---
+
+# JuMP Developers Meetup
+
+## When
+
+The JuMP developers meetup will take place at MIT, June 12-16, 2017.
+
+## Purpose
+
+The meetup is designed to serve as an opportunity for developers of mathematical optimization software within the JuMP "stack" (i.e., MathProgBase, JuMP, and JuMP extensions) to meet and focus on advancing common interests. JuMP core developers will present on the internals of JuMP and solicit feedback in preparation for the release of JuMP 1.0 (targeted for July, 2017). Attendees are welcome to contribute to the JuMP stack itself or to pursue JuMP-related projects while having the JuMP developers in the same room for questions and feedback.
+
+
+## Schedule
+
+### Monday
+
+- Presentations on MathProgBase and JuMP internals
+- Guest speaker: <a href="http://stanford.edu/~stevend2/">Steven Diamond</a> (Stanford, developer of <a href="https://github.com/cvxgrp/cvxpy">cvxpy</a>)
+- Attendee presentations
+
+### Tuesday
+
+- Attendee presentations
+- Hackathon
+
+### Wednesday, Thursday, Friday
+
+- Hackathon
+
+
+## Contact
+
+Contact mlubin at mit.edu for more information, or if you are interested in attending and have not received an invitation. 


### PR DESCRIPTION
Designed to provide information to people who are already attending or for justifying a week-long absence. I don't plan on linking to this from the main juliaopt.org page (in the near future).

@joehuchette @juan-pablo-vielma