### PR TITLE
tweak wording for JuMP-dev

### DIFF
--- a/meetings/bordeaux2018/index.md
+++ b/meetings/bordeaux2018/index.md
@@ -8,9 +8,9 @@ June 28-29, 2018, at the Institut de Mathématiques de Bordeaux, University of B
 
 ## Purpose
 
-This workshop is a follow-up to the [first annual JuMP-dev Workshop](/meetings/mit2017/) held in June 2017 at MIT. The purpose of the workshop is to bring together developers of mathematical optimization software based around the JuMP "stack". These include developers writing solvers in Julia, interfacing solvers from Julia, writing JuMP extensions (for problem classes such as stochastic, robust, and multiobjective), and developing other optimization libraries that utilize JuMP.
+This workshop is a follow-up to the [first annual JuMP-dev workshop](/meetings/mit2017/) held in June 2017 at MIT. The purpose of the workshop is to bring together students, researchers, and practitioners with interests in the software aspects of the JuMP "stack". These include developers writing solvers in Julia, interfacing solvers from Julia, writing JuMP extensions (for problem classes such as stochastic, robust, and multiobjective), and developing other optimization libraries that utilize JuMP.
 
-The workshop is a great opportunity to meet other developers working on and around JuMP, as well as to provide feedback to the core JuMP team concerning its future direction.
+The workshop is a great opportunity to meet other people working on and around JuMP, as well as to provide feedback to the core JuMP team concerning its future direction.
 
 ## Location
 
@@ -20,9 +20,10 @@ A variety of information about Bordeaux, as well as how to get there, and possib
 
 ## Call for participants
 
-The workshop is open for anybody to attend, however it is aimed at developers of mathematical optimization software who use JuMP rather than users. In particular, we encourage new contributors and those who have not met the core development team to attend.
+The workshop is open for anybody to attend. In particular, we invite new contributors and those who have not met the core development team.
 
-Participants are invited to give a 20-minute talk about their work that is related to JuMP. Talks should be aimed at a technical audience and demonstrate what you are using JuMP for, as well as the features that you like/dislike/have on your wishlist. Depending on the number of participants, we may not be able to accommodate all those who wish to talk. ([Here](https://www.youtube.com/watch?v=esOe5saQRKY&list=PLzK_rUGmc3o6EwPOCUCvBAbMJeYBS8PyY) is a playlist of talks from the previous workshop.)
+Participants are encouraged but not required to give a 20-minute talk about their work that is related to JuMP. Talks should be aimed at a technical audience and demonstrate what you are using JuMP for, as well as the features that you like/dislike/have on your wishlist. See [last year's talks](https://www.youtube.com/watch?v=esOe5saQRKY&list=PLzK_rUGmc3o6EwPOCUCvBAbMJeYBS8PyY) for a flavor of the workshop. Depending on the number of participants, we may not be able to accommodate all those who wish to talk.
+
 
 Please contact jump-dev-committee@googlegroups.com if you would like to attend.
 
@@ -51,8 +52,8 @@ A preliminary schedule is as follows.
 - Oscar Dowson
 - Benoît Legat
 - Joaquim Garcia
-- Issam Tahiri
-- François Vanderbeck
 - Juan Pablo Vielma
+- Issam Tahiri (Local Organization)
+- François Vanderbeck (Local Organization)
 
 Contact o.dowson at auckland.ac.nz or jump-dev-committee at googlegroups.com for more information.


### PR DESCRIPTION
We can be a bit more inclusive in our wording. It's better to describe what the workshop is about and let people decide if they want to attend rather than saying that it's not for certain not-clearly-defined classes of people.