### PR TITLE
Remove Graphs.jl from the list

### DIFF
--- a/packages/index.md
+++ b/packages/index.md
@@ -57,9 +57,7 @@ The ecosystem of [Julia packages](http://pkg.julialang.org) is growing very fast
 
 ## Graph and Network
 
-- [Graphs.jl](https://github.com/JuliaLang/Graphs.jl): Julia’s standard package for shortest path algorithms, minimum spanning tree algorithms, random graph generation, etc.
-
-- [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl): a similar package to Graphs.jl, defining a generic interface for graph types and an implementation with central algorithms.
+- [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl): defines a generic interface for graph types and an implementation with central algorithms.
 
 - [LightGraphsFlows.jl](https://github.com/JuliaGraphs/LightGraphsFlows.jl): solves max-flow and min-cut problems on top of `LightGraphs.jl`.
 


### PR DESCRIPTION
I don't see a reason to point people to an abandoned package given LightGraphs is an alternative.

@mbesancon