### PR TITLE
Fix Latex rendering for example HTMLs

### DIFF
--- a/notebooks/Chiwei Yan - Cutting Stock.html
+++ b/notebooks/Chiwei Yan - Cutting Stock.html
@@ -1022,6 +1022,11 @@ Cbc0045I Solution with objective value 453 saved
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>        
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/DualNumbers.html
+++ b/notebooks/DualNumbers.html
@@ -1003,6 +1003,11 @@ So $f'(z) = 2z$, and we can implement the algorithm as:</p>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>        
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/Dvorkin - Power systems - Economic dispatch and Unit commitment.html
+++ b/notebooks/Dvorkin - Power systems - Economic dispatch and Unit commitment.html
@@ -186,12 +186,12 @@
     <td>1000</td> 
   </tr>
   <tr>
-    <td>$c^g$, \$/MWh</td>
+    <td>$c^g$, $/MWh</td>
     <td>50</td> 
     <td>100</td> 
   </tr>
   <tr>
-    <td>$c^{g0}$, \$/MWh</td>
+    <td>$c^{g0}$, $/MWh</td>
     <td>1000</td> 
     <td>0</td> 
   </tr> 
@@ -227,7 +227,7 @@
     <td>50</td> 
   </tr>
   <tr>
-  <td>$c^{w}$, \$/MWh</td>
+  <td>$c^{w}$, $/MWh</td>
     <td>50</td> 
     <td>50</td> 
   </tr>
@@ -993,6 +993,11 @@ $$</p>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/JuMP-ChebyshevCenter.html
+++ b/notebooks/JuMP-ChebyshevCenter.html
@@ -1810,6 +1810,11 @@ fig.select("#fig-467bbd7339564db3b13ec745dbdcd5bd-element-21")
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/JuMP-LazyL2Ball.html
+++ b/notebooks/JuMP-LazyL2Ball.html
@@ -518,6 +518,11 @@ amount2:1-d})};a.filter.invert.toString=function(){return this()};a.filter.brigh
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+      });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/JuMP-Rocket.html
+++ b/notebooks/JuMP-Rocket.html
@@ -555,6 +555,11 @@ Max height: 1.012834061548546
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+      });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/Shuvomoy - Benders decomposition.html
+++ b/notebooks/Shuvomoy - Benders decomposition.html
@@ -1223,6 +1223,11 @@ Elapsed time = 0.83 sec. (0.04 ticks, tree = 0.00 MB, solutions = 1)
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/Shuvomoy - Column generation.html
+++ b/notebooks/Shuvomoy - Column generation.html
@@ -1214,6 +1214,11 @@ Reduced cost of the current solution is 0.0
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/Shuvomoy - Exploiting sparsity.html
+++ b/notebooks/Shuvomoy - Exploiting sparsity.html
@@ -1337,6 +1337,11 @@ trans: 1 dimensions, 63 entries:
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/Shuvomoy - Getting started with JuMP.html
+++ b/notebooks/Shuvomoy - Getting started with JuMP.html
@@ -1900,6 +1900,11 @@ Optimal y = y: 1 dimensions:
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- MathJax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>
     <script src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
   </body>
 </html>

--- a/notebooks/Shuvomoy - Getting started with JuMP.html
+++ b/notebooks/Shuvomoy - Getting started with JuMP.html
@@ -529,16 +529,16 @@ y = 0.0
 <p>This was certainly not the most exciting optimization problem to solve. This was for test purpose only. However, before going into the structure of a JuMP model, let us learn how to represent vectors in Julia.</p>
 <h1 id="Representing-vectors-in-Julia">Representing vectors in Julia<a class="anchor-link" href="#Representing-vectors-in-Julia">&#182;</a></h1><ul>
 <li><p>A column vector, $y=(y_1, y_2, \ldots, y_n)= \begin{pmatrix}
-y_1 \
-y_2 \
-. \
-. \
+y_1 \\
+y_2 \\
+. \\
+. \\
 y_n
 \end{pmatrix} \in \mathbb{R}^n$ will be written in Julia as <code>[y[1];y[2];...;y[n]]</code>.</p>
 <p>For example to create column vector $\begin{pmatrix}
-3 \
-2.4 \
-9.1 \
+3 \\
+2.4 \\
+9.1 
 \end{pmatrix}$  use: <code>[3; 2.4; 9.1]</code>.</p>
 </li>
 </ul>


### PR DESCRIPTION
Fixes #21 
As mentioned in the MathJax docs, `$...$` in-line delimiters are not used by default and must be enabled explicitly. I have enabled them for notebooks which had problems with rendering and handled cases where the $ sign appears occurs in the text(such as the Dvorkin power systems notebook) 