### PR TITLE
use JS to redirect fragment identifier

### DIFF
--- a/MathOptInterface.jl/dev/apimanual/index.html
+++ b/MathOptInterface.jl/dev/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/dev/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/dev/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/dev/apireference/index.html
+++ b/MathOptInterface.jl/dev/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/dev/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/dev/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/dev/index.html
+++ b/MathOptInterface.jl/dev/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/dev/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/dev/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/dev/search/index.html
+++ b/MathOptInterface.jl/dev/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/dev/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/dev/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/dev/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.1/apimanual.html
+++ b/MathOptInterface.jl/release-0.1/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.1/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.1/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.1/apireference.html
+++ b/MathOptInterface.jl/release-0.1/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.1/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.1/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.1/index.html
+++ b/MathOptInterface.jl/release-0.1/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.1/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.1/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.1/search.html
+++ b/MathOptInterface.jl/release-0.1/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.1/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.1/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.1/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.2/apimanual.html
+++ b/MathOptInterface.jl/release-0.2/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.2/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.2/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.2/apireference.html
+++ b/MathOptInterface.jl/release-0.2/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.2/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.2/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.2/index.html
+++ b/MathOptInterface.jl/release-0.2/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.2/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.2/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.2/search.html
+++ b/MathOptInterface.jl/release-0.2/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.2/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.2/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.2/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.3/apimanual.html
+++ b/MathOptInterface.jl/release-0.3/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.3/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.3/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.3/apireference.html
+++ b/MathOptInterface.jl/release-0.3/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.3/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.3/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.3/index.html
+++ b/MathOptInterface.jl/release-0.3/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.3/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.3/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.3/search.html
+++ b/MathOptInterface.jl/release-0.3/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.3/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.3/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.3/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.4/apimanual.html
+++ b/MathOptInterface.jl/release-0.4/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.4/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.4/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.4/apireference.html
+++ b/MathOptInterface.jl/release-0.4/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.4/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.4/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.4/index.html
+++ b/MathOptInterface.jl/release-0.4/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.4/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.4/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.4/search.html
+++ b/MathOptInterface.jl/release-0.4/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.4/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.4/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.4/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.5/apimanual.html
+++ b/MathOptInterface.jl/release-0.5/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.5/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.5/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.5/apireference.html
+++ b/MathOptInterface.jl/release-0.5/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.5/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.5/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.5/index.html
+++ b/MathOptInterface.jl/release-0.5/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.5/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.5/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.5/search.html
+++ b/MathOptInterface.jl/release-0.5/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.5/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.5/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.5/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.6/apimanual.html
+++ b/MathOptInterface.jl/release-0.6/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.6/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.6/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.6/apireference.html
+++ b/MathOptInterface.jl/release-0.6/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.6/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.6/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.6/index.html
+++ b/MathOptInterface.jl/release-0.6/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.6/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.6/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/release-0.6/search.html
+++ b/MathOptInterface.jl/release-0.6/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/release-0.6/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/release-0.6/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/release-0.6/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.1.0/apimanual.html
+++ b/MathOptInterface.jl/v0.1.0/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.1.0/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.1.0/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.1.0/apireference.html
+++ b/MathOptInterface.jl/v0.1.0/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.1.0/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.1.0/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.1.0/index.html
+++ b/MathOptInterface.jl/v0.1.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.1.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.1.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.1.0/search.html
+++ b/MathOptInterface.jl/v0.1.0/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.1.0/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.1.0/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.1.0/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.2.0/apimanual.html
+++ b/MathOptInterface.jl/v0.2.0/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.2.0/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.2.0/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.2.0/apireference.html
+++ b/MathOptInterface.jl/v0.2.0/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.2.0/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.2.0/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.2.0/index.html
+++ b/MathOptInterface.jl/v0.2.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.2.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.2.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.2.0/search.html
+++ b/MathOptInterface.jl/v0.2.0/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.2.0/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.2.0/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.2.0/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.3.0/apimanual.html
+++ b/MathOptInterface.jl/v0.3.0/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.3.0/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.3.0/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.3.0/apireference.html
+++ b/MathOptInterface.jl/v0.3.0/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.3.0/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.3.0/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.3.0/index.html
+++ b/MathOptInterface.jl/v0.3.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.3.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.3.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.3.0/search.html
+++ b/MathOptInterface.jl/v0.3.0/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.3.0/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.3.0/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.3.0/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.0/apimanual.html
+++ b/MathOptInterface.jl/v0.4.0/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.0/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.0/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.0/apireference.html
+++ b/MathOptInterface.jl/v0.4.0/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.0/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.0/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.0/index.html
+++ b/MathOptInterface.jl/v0.4.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.0/search.html
+++ b/MathOptInterface.jl/v0.4.0/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.0/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.0/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.0/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.1/apimanual.html
+++ b/MathOptInterface.jl/v0.4.1/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.1/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.1/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.1/apireference.html
+++ b/MathOptInterface.jl/v0.4.1/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.1/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.1/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.1/index.html
+++ b/MathOptInterface.jl/v0.4.1/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.1/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.1/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.4.1/search.html
+++ b/MathOptInterface.jl/v0.4.1/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.4.1/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.4.1/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.4.1/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.0/apimanual.html
+++ b/MathOptInterface.jl/v0.5.0/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.0/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.0/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.0/apireference.html
+++ b/MathOptInterface.jl/v0.5.0/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.0/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.0/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.0/index.html
+++ b/MathOptInterface.jl/v0.5.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.0/search.html
+++ b/MathOptInterface.jl/v0.5.0/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.0/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.0/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.0/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.1/apimanual.html
+++ b/MathOptInterface.jl/v0.5.1/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.1/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.1/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.1/apireference.html
+++ b/MathOptInterface.jl/v0.5.1/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.1/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.1/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.1/index.html
+++ b/MathOptInterface.jl/v0.5.1/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.1/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.1/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.5.1/search.html
+++ b/MathOptInterface.jl/v0.5.1/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.5.1/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.5.1/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.5.1/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.0/apimanual.html
+++ b/MathOptInterface.jl/v0.6.0/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.0/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.0/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.0/apireference.html
+++ b/MathOptInterface.jl/v0.6.0/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.0/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.0/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.0/index.html
+++ b/MathOptInterface.jl/v0.6.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.0/search.html
+++ b/MathOptInterface.jl/v0.6.0/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.0/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.0/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.0/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.1/apimanual.html
+++ b/MathOptInterface.jl/v0.6.1/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.1/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.1/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.1/apireference.html
+++ b/MathOptInterface.jl/v0.6.1/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.1/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.1/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.1/index.html
+++ b/MathOptInterface.jl/v0.6.1/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.1/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.1/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.1/search.html
+++ b/MathOptInterface.jl/v0.6.1/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.1/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.1/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.1/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.2/apimanual.html
+++ b/MathOptInterface.jl/v0.6.2/apimanual.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/apimanual.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.2/apimanual.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/apimanual.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.2/apimanual.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.2/apireference.html
+++ b/MathOptInterface.jl/v0.6.2/apireference.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/apireference.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.2/apireference.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/apireference.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.2/apireference.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.2/index.html
+++ b/MathOptInterface.jl/v0.6.2/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.2/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.2/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.2/search.html
+++ b/MathOptInterface.jl/v0.6.2/search.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/search.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.2/search.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.2/search.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.2/search.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.3/apimanual/index.html
+++ b/MathOptInterface.jl/v0.6.3/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.3/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.3/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.3/apireference/index.html
+++ b/MathOptInterface.jl/v0.6.3/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.3/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.3/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.3/index.html
+++ b/MathOptInterface.jl/v0.6.3/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.3/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.3/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.3/search/index.html
+++ b/MathOptInterface.jl/v0.6.3/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.3/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.3/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.3/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.4/apimanual/index.html
+++ b/MathOptInterface.jl/v0.6.4/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.4/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.4/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.4/apireference/index.html
+++ b/MathOptInterface.jl/v0.6.4/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.4/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.4/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.4/index.html
+++ b/MathOptInterface.jl/v0.6.4/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.4/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.4/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.6.4/search/index.html
+++ b/MathOptInterface.jl/v0.6.4/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.6.4/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.6.4/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.6.4/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.7.0/apimanual/index.html
+++ b/MathOptInterface.jl/v0.7.0/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.7.0/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.7.0/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.7.0/apireference/index.html
+++ b/MathOptInterface.jl/v0.7.0/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.7.0/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.7.0/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.7.0/index.html
+++ b/MathOptInterface.jl/v0.7.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.7.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.7.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.7.0/search/index.html
+++ b/MathOptInterface.jl/v0.7.0/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.7.0/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.7.0/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.7.0/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.0/apimanual/index.html
+++ b/MathOptInterface.jl/v0.8.0/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.0/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.0/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.0/apireference/index.html
+++ b/MathOptInterface.jl/v0.8.0/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.0/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.0/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.0/index.html
+++ b/MathOptInterface.jl/v0.8.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.0/search/index.html
+++ b/MathOptInterface.jl/v0.8.0/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.0/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.0/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.0/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.1/apimanual/index.html
+++ b/MathOptInterface.jl/v0.8.1/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.1/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.1/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.1/apireference/index.html
+++ b/MathOptInterface.jl/v0.8.1/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.1/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.1/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.1/index.html
+++ b/MathOptInterface.jl/v0.8.1/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.1/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.1/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.1/search/index.html
+++ b/MathOptInterface.jl/v0.8.1/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.1/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.1/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.1/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.3/apimanual/index.html
+++ b/MathOptInterface.jl/v0.8.3/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.3/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.3/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.3/apireference/index.html
+++ b/MathOptInterface.jl/v0.8.3/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.3/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.3/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.3/index.html
+++ b/MathOptInterface.jl/v0.8.3/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.3/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.3/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.3/search/index.html
+++ b/MathOptInterface.jl/v0.8.3/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.3/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.3/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.3/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.4/apimanual/index.html
+++ b/MathOptInterface.jl/v0.8.4/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.4/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.4/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.4/apireference/index.html
+++ b/MathOptInterface.jl/v0.8.4/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.4/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.4/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.4/index.html
+++ b/MathOptInterface.jl/v0.8.4/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.4/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.4/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.8.4/search/index.html
+++ b/MathOptInterface.jl/v0.8.4/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.8.4/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.8.4/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.8.4/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.0/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.0/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.0/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.0/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.0/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.0/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.0/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.0/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.0/index.html
+++ b/MathOptInterface.jl/v0.9.0/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.0/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.0/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.0/search/index.html
+++ b/MathOptInterface.jl/v0.9.0/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.0/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.0/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.0/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.1/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.1/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.1/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.1/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.1/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.1/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.1/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.1/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.1/index.html
+++ b/MathOptInterface.jl/v0.9.1/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.1/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.1/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.1/search/index.html
+++ b/MathOptInterface.jl/v0.9.1/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.1/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.1/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.1/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.10/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.10/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.10/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.10/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.10/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.10/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.10/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.10/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.10/index.html
+++ b/MathOptInterface.jl/v0.9.10/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.10/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.10/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.10/search/index.html
+++ b/MathOptInterface.jl/v0.9.10/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.10/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.10/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.10/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.11/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.11/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.11/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.11/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.11/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.11/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.11/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.11/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.11/index.html
+++ b/MathOptInterface.jl/v0.9.11/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.11/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.11/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.11/search/index.html
+++ b/MathOptInterface.jl/v0.9.11/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.11/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.11/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.11/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.12/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.12/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.12/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.12/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.12/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.12/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.12/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.12/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.12/index.html
+++ b/MathOptInterface.jl/v0.9.12/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.12/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.12/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.12/search/index.html
+++ b/MathOptInterface.jl/v0.9.12/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.12/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.12/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.12/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.13/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.13/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.13/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.13/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.13/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.13/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.13/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.13/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.13/index.html
+++ b/MathOptInterface.jl/v0.9.13/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.13/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.13/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.13/search/index.html
+++ b/MathOptInterface.jl/v0.9.13/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.13/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.13/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.13/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.14/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.14/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.14/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.14/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.14/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.14/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.14/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.14/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.14/index.html
+++ b/MathOptInterface.jl/v0.9.14/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.14/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.14/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.14/search/index.html
+++ b/MathOptInterface.jl/v0.9.14/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.14/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.14/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.14/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.2/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.2/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.2/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.2/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.2/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.2/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.2/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.2/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.2/index.html
+++ b/MathOptInterface.jl/v0.9.2/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.2/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.2/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.2/search/index.html
+++ b/MathOptInterface.jl/v0.9.2/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.2/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.2/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.2/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.3/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.3/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.3/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.3/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.3/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.3/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.3/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.3/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.3/index.html
+++ b/MathOptInterface.jl/v0.9.3/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.3/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.3/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.3/search/index.html
+++ b/MathOptInterface.jl/v0.9.3/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.3/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.3/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.3/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.4/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.4/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.4/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.4/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.4/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.4/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.4/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.4/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.4/index.html
+++ b/MathOptInterface.jl/v0.9.4/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.4/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.4/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.4/search/index.html
+++ b/MathOptInterface.jl/v0.9.4/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.4/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.4/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.4/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.5/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.5/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.5/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.5/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.5/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.5/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.5/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.5/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.5/index.html
+++ b/MathOptInterface.jl/v0.9.5/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.5/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.5/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.5/search/index.html
+++ b/MathOptInterface.jl/v0.9.5/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.5/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.5/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.5/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.6/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.6/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.6/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.6/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.6/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.6/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.6/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.6/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.6/index.html
+++ b/MathOptInterface.jl/v0.9.6/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.6/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.6/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.6/search/index.html
+++ b/MathOptInterface.jl/v0.9.6/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.6/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.6/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.6/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.7/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.7/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.7/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.7/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.7/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.7/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.7/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.7/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.7/index.html
+++ b/MathOptInterface.jl/v0.9.7/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.7/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.7/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.7/search/index.html
+++ b/MathOptInterface.jl/v0.9.7/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.7/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.7/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.7/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.8/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.8/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.8/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.8/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.8/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.8/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.8/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.8/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.8/index.html
+++ b/MathOptInterface.jl/v0.9.8/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.8/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.8/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.8/search/index.html
+++ b/MathOptInterface.jl/v0.9.8/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.8/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.8/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.8/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.9/apimanual/index.html
+++ b/MathOptInterface.jl/v0.9.9/apimanual/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Manual · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/apimanual/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.9/apimanual/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/apimanual/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.9/apimanual/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.9/apireference/index.html
+++ b/MathOptInterface.jl/v0.9.9/apireference/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Reference · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/apireference/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.9/apireference/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/apireference/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.9/apireference/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.9/index.html
+++ b/MathOptInterface.jl/v0.9.9/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Introduction · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.9/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.9/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.

--- a/MathOptInterface.jl/v0.9.9/search/index.html
+++ b/MathOptInterface.jl/v0.9.9/search/index.html
@@ -3,8 +3,13 @@
 <head>
 <meta charset="utf-8">
 <title>Search · MathOptInterface</title>
-<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/search/index.html">
 <link rel="canonical" href="https://jump.dev/MathOptInterface.jl/v0.9.9/search/index.html">
+<noscript>
+<meta http-equiv="refresh" content="3; URL=https://jump.dev/MathOptInterface.jl/v0.9.9/search/index.html">
+</noscript>
+<script type="text/javascript">
+window.location.replace("https://jump.dev/MathOptInterface.jl/v0.9.9/search/index.html" + window.location.hash);
+</script>
 </head>
 <body>
 This documentation page has moved from juliaopt.org to jump.dev.


### PR DESCRIPTION
Currently http://www.juliaopt.org/MathOptInterface.jl/v0.9.1/apimanual/#Duals-1 redirects to http://jump.dev/MathOptInterface.jl/v0.9.1/apimanual/. With this change it redirects to http://jump.dev/MathOptInterface.jl/v0.9.1/apimanual/#Duals-1.